### PR TITLE
Remove check_auth functionality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,9 +51,6 @@ Examples:
  - ``courseraoauth2client config authorize --app APP``
 
    Configures the tool to go through the `authorization secret <https://tools.ietf.org/html/rfc6749#section-4.1>`_ flow for application ``APP``.
- - ``courseraoauth2client config check-auth --app APP``
-
-   Checks whether the current instance can authorize against Coursera's API server for application ``APP``
 
 Usage
 -----------
@@ -64,7 +61,7 @@ Usage
   from courseraoauth2client import oauth2
   ...
   app = 'my_application_name'
-  url = 'https://api.coursera.org/api/externalBasicProfiles.v1?q=me&fields=name'
+  url = 'https://api.coursera.org/api/<your-api-endpoint>'
   auth = oauth2.build_oauth2(app=app).build_authorizer()
   response = requests.get(url, auth=auth)
   print response.json()

--- a/courseraoauth2client/commands/config.py
+++ b/courseraoauth2client/commands/config.py
@@ -22,10 +22,8 @@ You may install it from source, or via pip.
 
 from courseraoauth2client import oauth2
 import argparse
-import requests
 import logging
 import time
-import sys
 
 
 def authorize(args):
@@ -36,47 +34,6 @@ def authorize(args):
     oauth2_instance = oauth2.build_oauth2(args.app, args)
     oauth2_instance.build_authorizer()
     logging.info('Application "%s" authorized!', args.app)
-
-
-def check_auth(args):
-    """
-    Checks courseraoauth2client's connectivity to the coursera.org API servers
-    for a specific application
-    """
-    oauth2_instance = oauth2.build_oauth2(args.app, args)
-    auth = oauth2_instance.build_authorizer()
-    my_profile_url = (
-        'https://api.coursera.org/api/externalBasicProfiles.v1?'
-        'q=me&fields=name'
-    )
-    r = requests.get(my_profile_url, auth=auth)
-    if r.status_code != 200:
-        logging.error('Received response code %s from the basic profile API.',
-                      r.status_code)
-        logging.debug('Response body:\n%s', r.text)
-        sys.exit(1)
-    try:
-        external_id = r.json()['elements'][0]['id']
-    except:
-        logging.error(
-            'Could not parse the external id out of the response body %s',
-            r.text)
-        external_id = None
-
-    try:
-        name = r.json()['elements'][0]['name']
-    except:
-        logging.error(
-            'Could not parse the name out of the response body %s',
-            r.text)
-        name = None
-
-    if not args.quiet > 0:
-        print 'Name: %s' % name
-        print 'External ID: %s' % external_id
-
-    if name is None or external_id is None:
-        sys.exit(1)
 
 
 def display_auth_cache(args):
@@ -127,13 +84,6 @@ def parser(subparsers):
         help=authorize.__doc__,
         parents=[app_subparser])
     parser_authorize.set_defaults(func=authorize)
-
-    # Ensure your auth is set up correctly
-    parser_check_auth = config_subparsers.add_parser(
-        'check-auth',
-        help=check_auth.__doc__,
-        parents=[app_subparser])
-    parser_check_auth.set_defaults(func=check_auth)
 
     parser_local_cache = config_subparsers.add_parser(
         'display-auth-cache',


### PR DESCRIPTION
### Jira
https://coursera.atlassian.net/browse/LO-3927

### Description
`externalBasicProfiles.v1` is being deprecated.  This PR proposes removing `check_auth` entirely. This is a diagnostic/convenience utility, not part of the core functionality of this repo. Given that there are more modern, well-supported solutions in place for business auth ([thread1](https://coursera.slack.com/archives/C30LWF210/p1769141880381689?thread_ts=1769110097.315399&cid=C30LWF210), [thread2](https://coursera.slack.com/archives/C068XEWPYGL/p1745873560579249)), I'm not sure that more time should be invested than this. Let me know if otherwise, thanks!

FYI No alternative, modern profile endpoints with the correct `view_profile` scope were found. We can look into making that possible if needed ([ticket](https://coursera.atlassian.net/browse/SRES-849))

### Testing
Running unit tests